### PR TITLE
Fix SDL3 build and wrapper bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,10 @@ include(cmake/cpm.cmake)
 if(WIN32)
     include(cmake/cpm-sdl3.cmake)
 else()
-    find_package(SDL3 REQUIRED)
+    find_package(SDL3 QUIET)
+    if(NOT SDL3_FOUND)
+        include(cmake/cpm-sdl3.cmake)
+    endif()
 endif()
 
 # ImGUI

--- a/cmake/cpm-imgui.cmake
+++ b/cmake/cpm-imgui.cmake
@@ -40,11 +40,7 @@ if(imgui_ADDED)
   endif()
 
   
-  if(BUILD_SHARED_LIBS OR NOT WIN32)
-    target_link_libraries(imgui PUBLIC SDL3::SDL3-shared)
-  else()
-    target_link_libraries(imgui PUBLIC SDL3::SDL3-static)
-  endif()
+  target_link_libraries(imgui PUBLIC SDL3::SDL3)
 
   set_target_properties(imgui PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/src/ui_std.cpp
+++ b/src/ui_std.cpp
@@ -37,7 +37,7 @@ namespace ImGui {
     }
 
     bool Checkbox(const std::string &label, bool *v) {
-        return Checkbox(label.c_str(), v);
+        return ImGui::Checkbox(label.c_str(), v);
     }
 
     bool CollapsingHeader(const std::string &label, ImGuiTreeNodeFlags flags) {


### PR DESCRIPTION
## Summary
- fallback to CPM SDL3 if system package missing
- fix ImGui Checkbox wrapper to call underlying function directly

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6872463c652c83298d59bd1d124127b3