### PR TITLE
Add vcpkg SDL3 to CI and update UI demo to use UiState; require SDL3 CONFIG in CMake

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,19 +22,19 @@ jobs:
             c_compiler: cl
             cpp_compiler: cl
             vcpkg_triplet: x64-windows
-            vcpkg_commit_id: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
+            vcpkg_commit_id: 1e199d32ad53aab1defda61ce41c380302e3f95c
 
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
             vcpkg_triplet: x64-linux
-            vcpkg_commit_id: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
+            vcpkg_commit_id: 1e199d32ad53aab1defda61ce41c380302e3f95c
 
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
             vcpkg_triplet: x64-linux
-            vcpkg_commit_id: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
+            vcpkg_commit_id: 1e199d32ad53aab1defda61ce41c380302e3f95c
         exclude:
           - os: windows-2025
             c_compiler: gcc

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      
+
       matrix:
         os: [ubuntu-latest, windows-2025]
         build_type: [Release]
@@ -21,21 +21,24 @@ jobs:
           - os: windows-2025
             c_compiler: cl
             cpp_compiler: cl
-          
+            vcpkg_triplet: x64-windows
+
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-            
+            vcpkg_triplet: x64-linux
+
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
+            vcpkg_triplet: x64-linux
         exclude:
           - os: windows-2025
             c_compiler: gcc
-            
+
           - os: windows-2025
             c_compiler: clang
-          
+
           - os: ubuntu-latest
             c_compiler: cl
 
@@ -50,6 +53,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends xorg-dev libglu1-mesa-dev
 
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+
+    - name: Install SDL3 via vcpkg
+      run: vcpkg install sdl3:${{ matrix.vcpkg_triplet }}
+
     - name: Set reusable strings
       id: strings
       shell: bash
@@ -62,6 +71,8 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_INSTALLATION_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}
         -S ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -57,6 +57,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends xorg-dev libglu1-mesa-dev autoconf autoconf-archive automake libtool
 
     - name: Setup vcpkg
+      id: runvcpkg
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
@@ -77,7 +78,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_INSTALLATION_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
         -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}
         -S ${{ github.workspace }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -54,7 +54,16 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends xorg-dev libglu1-mesa-dev autoconf autoconf-archive automake libtool
+        sudo apt-get install -y --no-install-recommends \
+          autoconf autoconf-archive automake libtool libltdl-dev \
+          build-essential git make pkg-config cmake ninja-build \
+          gnome-desktop-testing libasound2-dev libpulse-dev libaudio-dev \
+          libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
+          libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev \
+          libxtst-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev \
+          libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev \
+          libudev-dev libthai-dev libpipewire-0.3-dev libwayland-dev \
+          libdecor-0-dev liburing-dev
 
     - name: Setup vcpkg
       id: runvcpkg

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -54,7 +54,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends xorg-dev libglu1-mesa-dev
+        sudo apt-get install -y --no-install-recommends xorg-dev libglu1-mesa-dev autoconf autoconf-archive automake libtool
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,16 +22,19 @@ jobs:
             c_compiler: cl
             cpp_compiler: cl
             vcpkg_triplet: x64-windows
+            vcpkg_commit_id: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
 
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
             vcpkg_triplet: x64-linux
+            vcpkg_commit_id: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
 
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
             vcpkg_triplet: x64-linux
+            vcpkg_commit_id: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
         exclude:
           - os: windows-2025
             c_compiler: gcc
@@ -55,6 +58,9 @@ jobs:
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+        vcpkgGitCommitId: '${{ matrix.vcpkg_commit_id }}'
 
     - name: Install SDL3 via vcpkg
       run: vcpkg install sdl3:${{ matrix.vcpkg_triplet }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ option(BUILD_SHARED_LIBS "Build shared libs" ON)
 # Dependencies
 #
 
-find_package(SDL3 REQUIRED)
+find_package(SDL3 CONFIG REQUIRED)
+
 include(3rdparty/imgui.cmake)
 include(3rdparty/implot.cmake)
 

--- a/src_demo/window_demo.cpp
+++ b/src_demo/window_demo.cpp
@@ -15,7 +15,7 @@
 //
 
 namespace Uni::GUI::Example {
-    bool WindowDemo::UiUpdate(UiApp& app) {
+    bool WindowDemo::UiUpdate(UiState& state) {
         static bool win_about = false;
         static bool win_demo = false;
         static bool win_demo_implot = false;
@@ -24,7 +24,7 @@ namespace Uni::GUI::Example {
         ImGui::SetNextWindowSize({800,600});
         if (ImGui::Begin("demo"))
         {
-            ImGui::Text(std::string(app.GetRenderingApiName()).c_str());
+            ImGui::Text("%s", std::string(state.app->GetRenderingApiName()).c_str());
 
             if (ImGui::Button("About"))
             {

--- a/src_demo/window_demo.h
+++ b/src_demo/window_demo.h
@@ -15,7 +15,7 @@ namespace Uni::GUI::Example {
     class WindowDemo: public Uni::GUI::UiElement {
     public:
         explicit WindowDemo() = default;
-        bool UiUpdate(UiApp&) override;
+        bool UiUpdate(UiState&) override;
     };
 }
 


### PR DESCRIPTION
### Motivation
- Ensure SDL3 is installed consistently across platforms and compilers in CI by integrating `vcpkg` and using vcpkg triplets.
- Make CMake prefer the config-mode package from `vcpkg` by using `find_package(SDL3 CONFIG REQUIRED)` to locate vcpkg-provided SDL3.
- Apply a small API refactor in the demo so the demo UI element uses `UiState` instead of `UiApp` and prints the rendering API name safely with `ImGui::Text`.

### Description
- CI: updated `.github/workflows/cmake-multi-platform.yml` to add `lukka/run-vcpkg@v11`, install `sdl3` via `vcpkg`, add `vcpkg_triplet` entries to the matrix, and pass `-DCMAKE_TOOLCHAIN_FILE` and `-DVCPKG_TARGET_TRIPLET` to CMake configure. 
- CMake: changed `find_package(SDL3 REQUIRED)` to `find_package(SDL3 CONFIG REQUIRED)` in `CMakeLists.txt` to favor config-mode discovery from vcpkg. 
- API change: modified `src_demo/window_demo.h` and `src_demo/window_demo.cpp` to change the signature from `bool UiUpdate(UiApp&)` to `bool UiUpdate(UiState&)`, updated usage to `state.app->GetRenderingApiName()`, and adjusted the `ImGui::Text` call to use `"%s"` with `c_str()`.

### Testing
- No automated tests were executed as part of this change in the patch; the GitHub Actions workflow was updated so CI will run on the next push or pull request to `main` using the new `vcpkg` steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accac4a39083299c19f3cb7cd93543)